### PR TITLE
Add support for callbacks on table structure changes

### DIFF
--- a/Slave.cpp
+++ b/Slave.cpp
@@ -176,7 +176,8 @@ void Slave::createTable(RelayLogInfo& rli,
     conn.query("SHOW FULL COLUMNS FROM " + tbl_name + " IN " + db_name);
     conn.store(res);
 
-    std::unique_ptr<Table> table(new Table(db_name, tbl_name));
+    Table *table_ = new Table(db_name, tbl_name);
+    std::unique_ptr<Table> table(table_);
 
     LOG_DEBUG(log, "Created new Table object: database:" << db_name << " table: " << tbl_name );
 
@@ -338,6 +339,11 @@ void Slave::createTable(RelayLogInfo& rli,
 
     rli.setTable(tbl_name, db_name, std::move(table));
 
+    const auto key = std::make_pair(db_name, tbl_name);
+    auto it = m_ddl_callbacks.find(key);
+    if (it != m_ddl_callbacks.end()) {
+        it->second(db_name, tbl_name, table_->fields);
+    }
 }
 
 namespace

--- a/Slave.h
+++ b/Slave.h
@@ -50,6 +50,7 @@ public:
     typedef std::set<std::pair<std::string, std::string>> table_order_t;
     typedef std::map<std::pair<std::string, std::string>, callback> callbacks_t;
     typedef std::map<std::pair<std::string, std::string>, filter> filters_t;
+    typedef std::map<std::pair<std::string, std::string>, ddl_callback> ddl_callbacks_t;
 
     typedef std::vector<std::string> cols_t;
     typedef std::map<std::pair<std::string, std::string>, cols_t> column_filters_t;
@@ -71,6 +72,7 @@ private:
 
     table_order_t m_table_order;
     callbacks_t m_callbacks;
+    ddl_callbacks_t m_ddl_callbacks;
     filters_t m_filters;
     column_filters_t m_column_filters;
     row_types_t m_row_types;
@@ -126,6 +128,12 @@ public:
         m_row_types[key] = row_type;
 
         ext_state.initTableCount(_db_name + "." + _tbl_name);
+    }
+
+    void setDDLCallback(const std::string& _db_name, const std::string& _tbl_name, ddl_callback _callback)
+    {
+        const std::pair<std::string, std::string> key = std::make_pair(_db_name, _tbl_name);
+        m_ddl_callbacks[key] = _callback;
     }
 
     void setXidCallback(xid_callback_t _callback)

--- a/table.h
+++ b/table.h
@@ -32,6 +32,7 @@ namespace slave
 
 typedef std::unique_ptr<Field> PtrField;
 typedef std::function<void (RecordSet&)> callback;
+typedef std::function<void (const std::string &, const std::string &, const std::vector<PtrField> &)> ddl_callback;
 typedef EventKind filter;
 
 


### PR DESCRIPTION
Allow setting callbacks on structure changes for tables of interest. As of now, there's no easy way for libslave client to directly hook into database schema.