### PR TITLE
Fix alter with leading comment

### DIFF
--- a/Slave.cpp
+++ b/Slave.cpp
@@ -796,7 +796,7 @@ namespace
 {
 std::string checkAlterOrCreateQuery(const std::string& str)
 {
-    static const std::regex query_regex(R"(\s*(?:alter\s+table|create\s+table(?:\s+if\s+not\s+exists)?)\s+(?:`?\w+`?\.)?`?(\w+)`?(?:[^\w\.`].*$|$))",
+    static const std::regex query_regex(R"((?:\s*\/\*.*?\*\/)*\s*(?:alter\s+table|create\s+table(?:\s+if\s+not\s+exists)?)\s+(?:`?\w+`?\.)?`?(\w+)`?(?:[^\w\.`].*$|$))",
                                         std::regex_constants::optimize | std::regex_constants::icase);
 
     std::string s;


### PR DESCRIPTION
Rebuild database structure on alter query with leading comment e.g.
        /\*CLion 2019.3\*/ ALTER TABLE foo.bar DROP COLUMN buzz