### PR TITLE
Fix for alter query in non-default database v2

### DIFF
--- a/Slave.h
+++ b/Slave.h
@@ -37,6 +37,7 @@
 #include "binlog_pos.h"
 #include "slave_log_event.h"
 #include "SlaveStats.h"
+#include "TableKey.h"
 
 
 namespace slave
@@ -47,14 +48,14 @@ class Slave
 {
 public:
 
-    typedef std::set<std::pair<std::string, std::string>> table_order_t;
-    typedef std::map<std::pair<std::string, std::string>, callback> callbacks_t;
-    typedef std::map<std::pair<std::string, std::string>, filter> filters_t;
-    typedef std::map<std::pair<std::string, std::string>, ddl_callback> ddl_callbacks_t;
+    typedef std::set<TableKey> table_order_t;
+    typedef std::map<TableKey, callback> callbacks_t;
+    typedef std::map<TableKey, filter> filters_t;
+    typedef std::map<TableKey, ddl_callback> ddl_callbacks_t;
 
     typedef std::vector<std::string> cols_t;
-    typedef std::map<std::pair<std::string, std::string>, cols_t> column_filters_t;
-    typedef std::map<std::pair<std::string, std::string>, RowType> row_types_t;
+    typedef std::map<TableKey, cols_t> column_filters_t;
+    typedef std::map<TableKey, RowType> row_types_t;
 
 private:
     static inline bool falseFunction() { return false; };
@@ -114,13 +115,13 @@ public:
                      const cols_t& column_filter, RowType row_type = RowType::Map, EventKind filter = eAll)
     {
         setCallback(_db_name, _tbl_name, _callback, row_type, filter);
-        m_column_filters[std::make_pair(_db_name, _tbl_name)] = column_filter;
+        m_column_filters[{_db_name, _tbl_name}] = column_filter;
     }
 
     void setCallback(const std::string& _db_name, const std::string& _tbl_name, callback _callback,
                      RowType row_type = RowType::Map, EventKind filter = eAll)
     {
-        const std::pair<std::string, std::string> key = std::make_pair(_db_name, _tbl_name);
+        const TableKey key{_db_name, _tbl_name};
         m_table_order.insert(key);
         m_callbacks[key] = _callback;
         m_filters[key] = filter;
@@ -132,8 +133,7 @@ public:
 
     void setDDLCallback(const std::string& _db_name, const std::string& _tbl_name, ddl_callback _callback)
     {
-        const auto key = std::make_pair(_db_name, _tbl_name);
-        m_ddl_callbacks[key] = _callback;
+        m_ddl_callbacks[{_db_name, _tbl_name}] = _callback;
     }
 
     void setXidCallback(xid_callback_t _callback)

--- a/TableKey.cpp
+++ b/TableKey.cpp
@@ -1,0 +1,15 @@
+#include "TableKey.h"
+#include <utility>
+#include <tuple>
+
+namespace slave
+{
+    TableKey::TableKey(std::string db_name, std::string table_name)
+        : db_name(std::move(db_name)), table_name(std::move(table_name)) {}
+
+    bool operator<(const TableKey& lhs, const TableKey& rhs)
+    {
+        auto tie = [](const TableKey& tableKey) { return std::tie(tableKey.table_name, tableKey.db_name); };
+        return tie(lhs) < tie(rhs);
+    }
+}

--- a/TableKey.h
+++ b/TableKey.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+
+namespace slave
+{
+    struct TableKey
+    {
+        TableKey() = default;
+        TableKey(std::string db_name, std::string table_name);
+        std::string db_name;
+        std::string table_name;
+    };
+
+    bool operator<(const TableKey& lhs, const TableKey& rhs);
+}

--- a/relayloginfo.h
+++ b/relayloginfo.h
@@ -16,6 +16,7 @@
 #define __SLAVE_RELAYLOGINFO_H_
 
 #include "table.h"
+#include "TableKey.h"
 
 #include <map>
 #include <memory>
@@ -32,10 +33,10 @@ class RelayLogInfo {
 
 public:
 
-    typedef std::map<unsigned long, std::pair<std::string, std::string> > id_to_name_t;
+    typedef std::map<unsigned long, TableKey> id_to_name_t;
     id_to_name_t m_map_table_name;
 
-    typedef std::map<std::pair<std::string, std::string>, PtrTable> name_to_table_t;
+    typedef std::map<TableKey, PtrTable> name_to_table_t;
     name_to_table_t m_table_map;
 
 
@@ -46,21 +47,21 @@ public:
 
 
     void setTableName(unsigned long table_id, const std::string& table_name, const std::string& db_name) {
-        m_map_table_name[table_id] = std::make_pair(db_name, table_name);
+        m_map_table_name[table_id] = {db_name, table_name};
     }
 
-    const std::pair<std::string,std::string> getTableNameById(int table_id) const
+    TableKey getTableNameById(int table_id) const
     {
         id_to_name_t::const_iterator p = m_map_table_name.find(table_id);
 
         if (p != m_map_table_name.end()) {
             return p->second;
         } else {
-            return std::make_pair(std::string(), std::string());
+            return {};
         }
     }
 
-    const PtrTable& getTable(const std::pair<std::string, std::string>& key) const
+    const PtrTable& getTable(const TableKey& key) const
     {
         static const PtrTable empty;
         name_to_table_t::const_iterator p = m_table_map.find(key);
@@ -73,7 +74,7 @@ public:
 
     void setTable(const std::string& table_name, const std::string& db_name, PtrTable&& table)
     {
-        m_table_map[std::make_pair(db_name, table_name)] = std::move(table);
+        m_table_map[{db_name, table_name}] = std::move(table);
     }
 
 };

--- a/slave_log_event.cpp
+++ b/slave_log_event.cpp
@@ -614,9 +614,9 @@ namespace // anonymous
 
 void apply_row_event(slave::RelayLogInfo& rli, const Basic_event_info& bei, const Row_event_info& roi, ExtStateIface &ext_state, EventStatIface* event_stat) {
     EventKind kind = eventKind(bei.type);
-    std::pair<std::string,std::string> key = rli.getTableNameById(roi.m_table_id);
+    const TableKey key = rli.getTableNameById(roi.m_table_id);
 
-    LOG_DEBUG(log, "applyRowEvent(): " << roi.m_table_id << " " << key.first << "." << key.second);
+    LOG_DEBUG(log, "applyRowEvent(): " << roi.m_table_id << " " << key.db_name << "." << key.table_name);
 
     const auto& table = rli.getTable(key);
 


### PR DESCRIPTION
Database name in binary log QUERY_EVENT is the default database name (see https://dev.mysql.com/doc/internals/en/event-data-for-specific-event-types.html ).
One should use database name from query with fallback to the default
database name from QUERY_EVENT.

Also std::pair<std::string,std::string> was replaced with struct TableKey to improve readability.