### PR TITLE
Correctly merge in a GTID position from another client

### DIFF
--- a/Slave.h
+++ b/Slave.h
@@ -102,6 +102,8 @@ public:
         ext_state.setMasterPosition(_master_info.position);
     }
 
+    bool gtidModeEnabled() const { return m_gtid_enabled; }
+
     void linkEventStat(EventStatIface* _event_stat)
     {
         event_stat = _event_stat;

--- a/binlog_pos.cpp
+++ b/binlog_pos.cpp
@@ -114,6 +114,54 @@ void parse_list_cont(const std::string& aList, Cont& aCont, const char* delim = 
 namespace slave
 {
 
+// find the intersection of two transaction intervals
+gtid_interval_t intersectIntervals(const gtid_interval_t& x, const gtid_interval_t& y)
+{
+    // if any given interval is empty - the result is empty too
+    if (isIntervalEmpty(x) || isIntervalEmpty(y))
+        return makeEmptyInterval();
+    // check if there's no intersection
+    if (x.second < y.first || y.second < x.first)
+        return makeEmptyInterval();
+    return gtid_interval_t(std::max(x.first, y.first), std::min(x.second, y.second));
+}
+
+// find the intersection of two lists of transaction intervals
+gtid_interval_list_t intersectIntervalsLists(const gtid_interval_list_t& x, const gtid_interval_list_t& y)
+{
+    gtid_interval_list_t result;
+    // straightforward implementation here, time complexity is O(N*M)
+    // should be OK, since N and M aren't expected to differ greatly from 1
+    for (const auto& x_interval : x)
+    {
+        for (const auto& y_interval : y)
+        {
+            auto z_interval = intersectIntervals(x_interval, y_interval);
+            if (!isIntervalEmpty(z_interval))
+                result.push_back(z_interval);
+        }
+    }
+    return result;
+}
+
+// find the intersection of two GTID sets,
+// not very useful per se, see Position::shiftToThePast() instead
+gtid_set_t intersectGtidSets(const gtid_set_t& x, const gtid_set_t& y)
+{
+    gtid_set_t result;
+    for (const auto& [x_source, x_transactions] : x)
+    {
+        auto y_it = y.find(x_source);
+        if (y.end() != y_it)
+        {
+            auto z_transactions = intersectIntervalsLists(x_transactions, y_it->second);
+            if (!z_transactions.empty())
+                result.emplace(x_source, z_transactions);
+        }
+    }
+    return result;
+}
+
 // parseGtid parse string with gtid
 // example:  ae00751a-cb5f-11e6-9d92-e03f490fd3db:1-12:15-17
 // gtid_set: uuid_set [, uuid_set] ... | ''
@@ -250,6 +298,24 @@ void Position::encodeGtid(unsigned char* buf)
     }
 }
 
+// This method helps to rewind the current position of the client
+// back to as early in time as specified by another position,
+// which is typically received from a client reading some other replica.
+// In this situation we have to avoid adding any new sources,
+// that our client's replica isn't aware of, or binlog request will fail.
+void Position::shiftToThePast(const Position &other)
+{
+    if (gtid_executed.empty() || other.gtid_executed.empty())
+        throw std::runtime_error("Both positions should contain GTIDs");
+    auto result = intersectGtidSets(gtid_executed, other.gtid_executed);
+    for (const auto& [x_source, x_transactions] : gtid_executed)
+    {
+        if (result.end() == result.find(x_source))
+            result[x_source] = x_transactions;
+    }
+    std::swap(result, gtid_executed);
+}
+
 bool Position::reachedOtherPos(const Position& other) const
 {
     if (gtid_executed.empty() && other.gtid_executed.empty())
@@ -312,13 +378,16 @@ std::string Position::str() const
     if (!log_name.empty() && log_pos)
         result += log_name + ":" + std::to_string(log_pos) + ", ";
 
-    result += "GTIDs=";
-    if (gtid_executed.empty())
-    {
-        result += "-'";
-        return result;
-    }
+    result += "GTIDs=" + formatGtid() + "'";
+    return result;
+}
 
+std::string Position::formatGtid() const
+{
+    if (gtid_executed.empty())
+        return "-";
+
+    std::string result;
     bool first_a = true;
     for (const auto& gtid : gtid_executed)
     {
@@ -341,7 +410,6 @@ std::string Position::str() const
                 result += "-" + std::to_string(interv.second);
         }
     }
-    result += "'";
     return result;
 }
 

--- a/binlog_pos.h
+++ b/binlog_pos.h
@@ -1,21 +1,48 @@
 #pragma once
 
-#include <list>
+#include <vector>
 #include <string>
+#include <map>
 #include <ostream>
-#include <unordered_map>
 #include <utility>
 
 namespace slave
 {
 
-// interval of transactions with numbers from "first" to "second"
+// transaction interval with numbers from "first" to "second", inclusively
 using gtid_interval_t = std::pair<int64_t, int64_t>;
-// set of transactions:
-// key - source server uuid, value - list of transaction intervals
-using gtid_set_t = std::unordered_map<std::string, std::list<gtid_interval_t>>;
-// single transaction: first - server uuid, second - transaction number
+
+// any interval having "second" < "first" is considered empty
+inline bool isIntervalEmpty(const gtid_interval_t& x) { return x.second < x.first; }
+
+// any interval having "second" < "first" is considered empty
+inline gtid_interval_t makeEmptyInterval() { return gtid_interval_t(1, 0); }
+
+// find the intersection of two transaction intervals
+gtid_interval_t intersectIntervals(const gtid_interval_t& x, const gtid_interval_t& y);
+
+
+// list of transaction intervals, where the intervals are stored
+// in ascending order by initial transaction numbers
+using gtid_interval_list_t = std::vector<gtid_interval_t>;
+
+// find the intersection of two lists of transaction intervals
+gtid_interval_list_t intersectIntervalsLists(const gtid_interval_list_t& x,
+                                             const gtid_interval_list_t& y);
+
+
+// GTID set - represents a complete position in a binlog, actually a map:
+// key - source server uuid, value - list of its transaction intervals
+using gtid_set_t = std::map<std::string, gtid_interval_list_t>;
+
+// find the intersection of two GTID sets,
+// not very useful per se, see Position::shiftToThePast() instead
+gtid_set_t intersectGtidSets(const gtid_set_t& x, const gtid_set_t& y);
+
+
+// single transaction: first - source server uuid, second - transaction number
 using gtid_t = std::pair<std::string, int64_t>;
+
 
 struct Position
 {
@@ -38,9 +65,17 @@ struct Position
     size_t encodedGtidSize() const;
     void encodeGtid(unsigned char* buf);
 
+    // This method helps to rewind the current position of the client
+    // back to as early in time as specified by another position,
+    // which is typically received from a client reading some other replica.
+    // In this situation we have to avoid adding any new sources,
+    // that our client's replica isn't aware of, or binlog request will fail.
+    void shiftToThePast(const Position &other);
+
     bool reachedOtherPos(const Position& other) const;
 
     std::string str() const;
+    std::string formatGtid() const;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const Position& pos)

--- a/decimal.cpp
+++ b/decimal.cpp
@@ -113,7 +113,12 @@ std::string slave::decimal::to_string(const Decimal& d)
         auto x = *idigits.begin();
         intg_len -= count_leading_zeroes(x.second, x.first);
     }
-    size_t len = intg_len + d.frac + d.sign + (0 == intg_len ? 1 : 0) + (0 != d.frac ? 1 : 0);
+    // unsigned because with size_t -Werror=alloca-larger-than gives an error with gcc 10.2.0.
+    // I don't know why.
+    unsigned len = intg_len + d.frac + d.sign + (0 == intg_len ? 1 : 0) + (0 != d.frac ? 1 : 0);
+
+    if (len > 0xffff)
+        return "slave::decimal::to_string: len is too big = " + std::to_string(len);
 
     char* buf = reinterpret_cast<char*>(alloca(len));
     char *s = buf;

--- a/test/unit_test.cpp
+++ b/test/unit_test.cpp
@@ -1797,6 +1797,43 @@ namespace // anonymous
         BOOST_CHECK(ref6.front() == slave::gtid_interval_t(34, 34));
     }
 
+    void test_GtidFormatting()
+    {
+        slave::Position pos1;
+        BOOST_CHECK_EQUAL("'GTIDs=-'", pos1.str());
+        BOOST_CHECK_EQUAL("-", pos1.formatGtid());
+
+        const std::string uuid1Text = "24F7C945-C871-11E6-9461-0242AC110006";
+        slave::gtid_interval_list_t intervals;
+        intervals.push_back(slave::gtid_interval_t(100, 123));
+        intervals.push_back(slave::gtid_interval_t(200, 200));
+        pos1.gtid_executed[uuid1Text] = intervals;
+
+        BOOST_CHECK_EQUAL("24F7C945-C871-11E6-9461-0242AC110006:100-123:200", pos1.formatGtid());
+    }
+
+    void test_GtidIntersect()
+    {
+        slave::Position pos1;
+        const std::string uuid1Text = "24F7C945-C871-11E6-9461-0242AC110006";
+        slave::gtid_interval_list_t intervals1;
+        intervals1.push_back(slave::gtid_interval_t(100, 123));
+        intervals1.push_back(slave::gtid_interval_t(200, 200));
+        pos1.gtid_executed[uuid1Text] = intervals1;
+
+        slave::Position pos2;
+        slave::gtid_interval_list_t intervals2;
+        intervals2.push_back(slave::gtid_interval_t(120, 250));
+        pos2.gtid_executed[uuid1Text] = intervals2;
+        pos2.gtid_executed["24F7C945-C871-11E6-9461-0242AC110007"] = intervals1;
+
+        BOOST_CHECK_EQUAL("24F7C945-C871-11E6-9461-0242AC110006:120-250,"
+                          "24F7C945-C871-11E6-9461-0242AC110007:100-123:200", pos2.formatGtid());
+        pos2.shiftToThePast(pos1);
+        BOOST_CHECK_EQUAL("24F7C945-C871-11E6-9461-0242AC110006:120-123:200,"
+                          "24F7C945-C871-11E6-9461-0242AC110007:100-123:200", pos2.formatGtid());
+    }
+
     void test_GtidAdding()
     {
         slave::Position pos;
@@ -1997,6 +2034,8 @@ test_suite* init_unit_test_suite(int argc, char* argv[])
     ADD_FIXTURE_TEST(test_AlterCreateTable);
     ADD_FIXTURE_TEST(test_RenameTable);
     ADD_FIXTURE_TEST(test_GtidParsing);
+    ADD_FIXTURE_TEST(test_GtidFormatting);
+    ADD_FIXTURE_TEST(test_GtidIntersect);
     ADD_FIXTURE_TEST(test_GtidAdding);
     ADD_FIXTURE_TEST(test_GtidReached);
     ADD_FIXTURE_TEST(test_Decimal);


### PR DESCRIPTION
New method
```
void Position::shiftToThePast(const Position &other)
```
that helps to rewind the current position of the client back to as early in time as specified by another position,
which is typically received from a client reading some other replica.

In this situation we have to avoid adding any new sources, that our client's replica isn't aware of, or binlog request will fail.
